### PR TITLE
Makefile created

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+basicrt : basicrt.cpp
+	c++ -o basicrt -O3 -Wall basicrt.cpp

--- a/basicrt.cpp
+++ b/basicrt.cpp
@@ -66,6 +66,6 @@ public:
         const Vec3f &ec = 0) : 
         center(c), radius(r), radius2(r * r), surfaceColor(sc), emissionColor(ec), 
         transparency(transp), reflection(refl) 
-    { /* empty */ } 
-  
-  
+    { /* empty */ }
+ 
+};


### PR DESCRIPTION
MakeFile is added.
It will be used by typing `make basicrt` in the shell. The executable is named `basicrt`. C++17 standard is being followed with warning flags.